### PR TITLE
Several updates

### DIFF
--- a/src/magiccionary/magic.py
+++ b/src/magiccionary/magic.py
@@ -206,16 +206,32 @@ def _remove_empty_keys_inplace(data):
             if not value:
                 empty_keys.append(key)
         elif isinstance(value, list):
-            for item in value:
-                if isinstance(item, dict):
-                    _remove_empty_keys_inplace(item)
-                    if not item:
-                        empty_keys.append(key)
-                elif isinstance(item, str):
-                    if not item:
-                        empty_keys.append(key)
+            _prune_empty_list_items_inplace(value)
+            if not value:
+                empty_keys.append(key)
     for key in empty_keys:
         del data[key]
+
+
+def _prune_empty_list_items_inplace(lst):
+    """
+    Remove empty items (None, "", {}, []) from a list in-place,
+    recursing into nested dicts and lists.
+    """
+    for i in range(len(lst) - 1, -1, -1):
+        item = lst[i]
+        if item is None:
+            del lst[i]
+        elif isinstance(item, str) and not item:
+            del lst[i]
+        elif isinstance(item, dict):
+            _remove_empty_keys_inplace(item)
+            if not item:
+                del lst[i]
+        elif isinstance(item, list):
+            _prune_empty_list_items_inplace(item)
+            if not item:
+                del lst[i]
 
 
 def nested_update(original, update):

--- a/src/magiccionary/magic.py
+++ b/src/magiccionary/magic.py
@@ -11,11 +11,17 @@ def _remove_keys(data, single_key_to_remove):
     """
     first_key = single_key_to_remove[0]
     if first_key == "[]" and isinstance(data, list):
-        for item in data:
-            _remove_keys(item, single_key_to_remove[1:])
+        if len(single_key_to_remove) == 1:
+            data.clear()
+        else:
+            for item in data:
+                _remove_keys(item, single_key_to_remove[1:])
     elif first_key == "*" and isinstance(data, dict):
-        for key, value in data.items():
-            _remove_keys(value, single_key_to_remove[1:])
+        if len(single_key_to_remove) == 1:
+            data.clear()
+        else:
+            for value in data.values():
+                _remove_keys(value, single_key_to_remove[1:])
     elif len(single_key_to_remove) == 1:
         data.pop(first_key, None)
     elif first_key in data:
@@ -126,12 +132,16 @@ def _keep_keys(data, single_key_to_keep):
     first_key = single_key_to_keep[0]
 
     if first_key == "[]" and isinstance(data, list):
+        if len(single_key_to_keep) == 1:
+            return list(data)
         list_to_keep = []
         for item in data:
             list_to_keep.append(_keep_keys(item, single_key_to_keep[1:]))
         # Return the list as is
         return list_to_keep
     elif first_key == "*" and isinstance(data, dict):
+        if len(single_key_to_keep) == 1:
+            return dict(data)
         for key, value in data.items():
             dict_to_keep[key] = _keep_keys(value, single_key_to_keep[1:])
         return dict_to_keep

--- a/src/magiccionary/magic.py
+++ b/src/magiccionary/magic.py
@@ -22,6 +22,10 @@ def _remove_keys(data, single_key_to_remove):
         else:
             for value in data.values():
                 _remove_keys(value, single_key_to_remove[1:])
+    elif not isinstance(data, dict):
+        # Lists require the "[]" token to traverse; any other path segment
+        # is treated as a no-op rather than attempting list.pop(str).
+        return
     elif len(single_key_to_remove) == 1:
         data.pop(first_key, None)
     elif first_key in data:

--- a/tests/test_magic_keep_keys.py
+++ b/tests/test_magic_keep_keys.py
@@ -162,6 +162,33 @@ def test_keep_simple_two_level():
     assert actual == expected
 
 
+def test_keep_trailing_list_wildcard_keeps_all_items():
+    input = {"items": [1, 2, 3]}
+    expected = {"items": [1, 2, 3]}
+
+    actual = keep_keys(input, [["items", "[]"]])
+
+    assert actual == expected
+
+
+def test_keep_trailing_dict_wildcard_keeps_all_values():
+    input = {"users": {"a": 1, "b": 2}}
+    expected = {"users": {"a": 1, "b": 2}}
+
+    actual = keep_keys(input, [["users", "*"]])
+
+    assert actual == expected
+
+
+def test_keep_top_level_dict_wildcard_keeps_everything():
+    input = {"a": 1, "b": 2}
+    expected = {"a": 1, "b": 2}
+
+    actual = keep_keys(input, [["*"]])
+
+    assert actual == expected
+
+
 def test_keep_simple_non_existing_key():
     input = {
         "a": 1,

--- a/tests/test_magic_remove_keys.py
+++ b/tests/test_magic_remove_keys.py
@@ -314,6 +314,31 @@ def test_top_level_list_wildcard_clears_all_items():
     assert input == input_copy
 
 
+def test_descending_into_list_without_bracket_is_noop():
+    # Without the "[]" token, the path cannot address list items.
+    # Previously this raised TypeError from list.pop(str, None); now it
+    # is a silent no-op.
+    input = {"a": [{"b": 1}]}
+    input_copy = deepcopy(input)
+    expected = deepcopy(input)
+
+    actual = remove_keys(input, [["a", "b"]])
+
+    assert actual == expected
+    assert input == input_copy
+
+
+def test_descending_into_list_without_bracket_deeper_path():
+    input = {"a": [{"b": {"c": 1}}]}
+    input_copy = deepcopy(input)
+    expected = deepcopy(input)
+
+    actual = remove_keys(input, [["a", "b", "c"]])
+
+    assert actual == expected
+    assert input == input_copy
+
+
 def test_simple_three_level():
     input = {
         "a": {

--- a/tests/test_magic_remove_keys.py
+++ b/tests/test_magic_remove_keys.py
@@ -270,6 +270,50 @@ def test_simple_two_level():
     assert input == input_copy  # Input should remain unchanged
 
 
+def test_trailing_list_wildcard_clears_list():
+    input = {"items": [1, 2, 3]}
+    input_copy = deepcopy(input)
+    expected = {"items": []}
+
+    actual = remove_keys(input, [["items", "[]"]])
+
+    assert actual == expected
+    assert input == input_copy
+
+
+def test_trailing_dict_wildcard_clears_dict():
+    input = {"users": {"a": 1, "b": 2}}
+    input_copy = deepcopy(input)
+    expected = {"users": {}}
+
+    actual = remove_keys(input, [["users", "*"]])
+
+    assert actual == expected
+    assert input == input_copy
+
+
+def test_top_level_dict_wildcard_clears_all_keys():
+    input = {"a": 1, "b": 2}
+    input_copy = deepcopy(input)
+    expected = {}
+
+    actual = remove_keys(input, [["*"]])
+
+    assert actual == expected
+    assert input == input_copy
+
+
+def test_top_level_list_wildcard_clears_all_items():
+    input = [1, 2, 3]
+    input_copy = deepcopy(input)
+    expected = []
+
+    actual = remove_keys(input, [["[]"]])
+
+    assert actual == expected
+    assert input == input_copy
+
+
 def test_simple_three_level():
     input = {
         "a": {

--- a/tests/test_remove_empty_keys.py
+++ b/tests/test_remove_empty_keys.py
@@ -1,0 +1,103 @@
+from copy import deepcopy
+
+from magiccionary import remove_empty_keys
+
+
+def test_prunes_empty_dict_items_in_list_without_losing_neighbours():
+    # Previously the entire "posts" list was deleted because one item
+    # became empty. It should keep the non-empty post.
+    input = {"posts": [{"title": ""}, {"title": "B"}]}
+    input_copy = deepcopy(input)
+    expected = {"posts": [{"title": "B"}]}
+
+    actual = remove_empty_keys(input)
+
+    assert actual == expected
+    assert input == input_copy
+
+
+def test_prunes_nested_empty_items_keeps_populated_items():
+    input = {
+        "posts": [
+            {"nested": {}},
+            {"title": "B", "content": "C"},
+        ]
+    }
+    input_copy = deepcopy(input)
+    expected = {"posts": [{"title": "B", "content": "C"}]}
+
+    actual = remove_empty_keys(input)
+
+    assert actual == expected
+    assert input == input_copy
+
+
+def test_readme_example():
+    input = {
+        "name": "John",
+        "email": None,
+        "settings": {},
+        "posts": [
+            {"title": "Post 1", "content": ""},
+            {"title": "Post 2", "content": "Hello"},
+        ],
+    }
+    input_copy = deepcopy(input)
+    expected = {
+        "name": "John",
+        "posts": [
+            {"title": "Post 1"},
+            {"title": "Post 2", "content": "Hello"},
+        ],
+    }
+
+    actual = remove_empty_keys(input)
+
+    assert actual == expected
+    assert input == input_copy
+
+
+def test_removes_key_whose_value_is_empty_list():
+    input = {"a": [], "b": 1}
+    expected = {"b": 1}
+
+    actual = remove_empty_keys(input)
+
+    assert actual == expected
+
+
+def test_removes_key_whose_list_becomes_empty_after_pruning():
+    input = {"a": [None, "", {}], "b": 1}
+    expected = {"b": 1}
+
+    actual = remove_empty_keys(input)
+
+    assert actual == expected
+
+
+def test_prunes_empty_strings_and_nones_from_lists():
+    input = {"tags": ["x", None, "", "y"]}
+    expected = {"tags": ["x", "y"]}
+
+    actual = remove_empty_keys(input)
+
+    assert actual == expected
+
+
+def test_prunes_nested_lists():
+    input = {"matrix": [[1, 2], [], [None, ""], [3]]}
+    expected = {"matrix": [[1, 2], [3]]}
+
+    actual = remove_empty_keys(input)
+
+    assert actual == expected
+
+
+def test_preserves_falsy_non_empty_values():
+    # False and 0 are not in the "empty" set defined by the docstring.
+    input = {"flag": False, "count": 0, "empty_str": ""}
+    expected = {"flag": False, "count": 0}
+
+    actual = remove_empty_keys(input)
+
+    assert actual == expected


### PR DESCRIPTION
This pull request improves the handling of wildcards and empty values in dictionary and list manipulation utilities, and adds comprehensive tests to ensure correct behaviour. The changes enhance how keys are kept or removed using wildcards, and refactor the logic for pruning empty values from nested data structures.

**Enhancements to wildcard handling in key removal and retention:**

* Updated `_remove_keys` and `_keep_keys` in `magic.py` to properly handle trailing list (`"[]"`) and dict (`"*"` ) wildcards, so that when these are the last segment in the path, the entire list or dictionary is cleared or retained as appropriate. This prevents partial or incorrect removals/retentions. 

**Refactor and improvement of empty value pruning:**

* Refactored empty value removal by introducing `_prune_empty_list_items_inplace` to recursively prune empty items (like `None`, `""`, `{}`, `[]`) from lists, and updated `_remove_empty_keys_inplace` to use this helper, ensuring that only truly empty structures are removed and non-empty neighbors are preserved.

**Expanded and improved test coverage:**

* Added new tests in `test_magic_remove_keys.py` to verify correct behavior when removing keys with wildcards, including edge cases for lists and dicts, and ensuring that descending into lists without the bracket token is a no-op rather than an error.
* Added new tests in `test_magic_keep_keys.py` to verify that keeping keys with trailing wildcards retains all values/items as expected.
* Added a new test suite `test_remove_empty_keys.py` to verify that empty values are correctly pruned from nested structures, including lists of dicts and nested lists, without affecting non-empty neighbors or falsy but non-empty values like `False` and `0`.